### PR TITLE
Basic RedHat Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ postfix_relayhost_user: false
 
 # The password for SMTP authentication
 postfix_relayhost_pass: false
+
+# The interfaces for Postfix to listen on
+postfix_inet_interfaces: 'loopback-only'
 ```
 
 ## Examples

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,4 @@ postfix_relayhost: ''
 postfix_use_smtp: false
 postfix_relayhost_user: false
 postfix_relayhost_pass: false
+postfix_inet_interfaces: 'loopback-only'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,7 +58,7 @@
     backup=yes
   notify:
     - restart postfix
-    - send test email
+#    - send test email
   tags:
     - common
     - postfix

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,7 +58,7 @@
     backup=yes
   notify:
     - restart postfix
-#    - send test email
+    - send test email
   tags:
     - common
     - postfix

--- a/templates/main-cf.j2
+++ b/templates/main-cf.j2
@@ -40,4 +40,4 @@ relayhost = {{ postfix_relayhost }}
 mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
 mailbox_size_limit = 0
 recipient_delimiter = +
-inet_interfaces = all
+inet_interfaces = {{postfix_inet_interfaces}}

--- a/templates/main-cf.j2
+++ b/templates/main-cf.j2
@@ -5,7 +5,7 @@
 # is /etc/mailname.
 #myorigin = /etc/mailname
 
-smtpd_banner = $myhostname ESMTP $mail_name
+smtpd_banner = {{ ansible_fqdn }} ESMTP $mail_name
 biff = no
 
 # appending .domain is the MUA's job.
@@ -40,4 +40,4 @@ relayhost = {{ postfix_relayhost }}
 mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
 mailbox_size_limit = 0
 recipient_delimiter = +
-inet_interfaces = loopback-only
+inet_interfaces = all

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,6 @@
+---
+
+postfix_config_dir: '/etc/postfix'
+postfix_service: 'postfix'
+# Postfix included in default build, no deps
+postfix_packages: ''


### PR DESCRIPTION
# Changes:
- Created a `vars` file for portability to RedHat flavored systems. 
- Parameterized the inet_interfaces variable such that it is configurable in playbooks.
- Changed the banner to use the system FQDN to pass reverse DNS validation

I've tested this on a CentOS/EL6 system and it passes [MXToolbox diagnostics](http://mxtoolbox.com/diagnostic.aspx).
