### PR TITLE
Send test email after changing SMTP credentials

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,6 +45,7 @@
     mode=0600 owner=root group=root
   notify:
     - postmap sasl
+    - send test email
   when: postfix_use_smtp and postfix_relayhost_user and postfix_relayhost_pass
   tags:
     - common


### PR DESCRIPTION
It's good to know if your new SMTP credentials work or if perhaps you fat-fingered your username and broke your mail server. Not that I've ever done that.
