### PR TITLE
Test truth, not definedness, of variables.

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -25,4 +25,4 @@
 - name: send test email
   shell: >
     echo "This is a test message from Ansible configuration of {{ ansible_hostname }} at $(date -R)" | sendmail {{ postfix_notify_email }}
-  when: postfix_notify_email is defined
+  when: postfix_notify_email

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -68,7 +68,7 @@
     src=root-forward.j2
     dest=/root/.forward
     mode=0644 owner=root group=root
-  when: postfix_notify_email is defined
+  when: postfix_notify_email
   tags:
     - common
     - postfix

--- a/templates/main-cf.j2
+++ b/templates/main-cf.j2
@@ -18,7 +18,7 @@ smtpd_use_tls=yes
 smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
 smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 
-{% if postfix_use_smtp is defined and postfix_use_smtp == true %}
+{% if postfix_use_smtp and postfix_use_smtp == true %}
 # Enable SASL authentication
 smtp_sasl_auth_enable = yes
 smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd
@@ -36,4 +36,4 @@ alias_database = hash:/etc/aliases
 mailbox_size_limit = 0
 recipient_delimiter = +
 inet_interfaces = loopback-only
-relayhost = {% if postfix_relayhost is defined %}{{ postfix_relayhost }}{% else %}$mydomain{% endif %}
+relayhost = {% if postfix_relayhost %}{{ postfix_relayhost }}{% else %}$mydomain{% endif %}


### PR DESCRIPTION
Since we define default false-y values in `defaults/`, these variables
always exist, and the `is defined` check does nothing. Instead, check if
they've been assigned true values.
