### PR TITLE
use ansible_hostname rather than inventory_hostname

### DIFF
--- a/templates/main-cf.j2
+++ b/templates/main-cf.j2
@@ -27,7 +27,7 @@ smtp_use_tls = yes
 
 {% endif %}
 # General
-myhostname = {{ inventory_hostname }}
+myhostname = {{ ansible_hostname }}
 myorigin = $mydomain
 mydestination =
 mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128


### PR DESCRIPTION
Some dynamic inventory systems (such as ec2.py) set the inventory_hostname var to be an IP address; this produces an invalid value for the postfix 'myhostname' param.

To work round this, use the ansible_hostname var instead.
