### PR TITLE
fix install with ansible 2.9.6

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,7 +33,7 @@
   apt: >
     pkg={{ item }}
     update_cache=yes
-    state=installed
+    state=present
   with_items: '{{ postfix_packages }}'
   when: ansible_os_family == 'Debian'
   tags:


### PR DESCRIPTION
The deprecated apt package state, installed, has been removed since ansible 2.9.0. Use present instead.