### PR TITLE
install on ubuntu 20.04

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -5,7 +5,6 @@ postfix_config_dir: '/etc/postfix'
 postfix_service: 'postfix'
 postfix_packages:
   - 'ca-certificates'
-  - 'heirloom-mailx'
   - 'libsasl2-2'
   - 'libsasl2-modules'
   - 'mailutils'


### PR DESCRIPTION
heirloom-mailx has been a dummy package since at least Ubuntu 16.04. Without being installed, mailx is provided by the mailutils package.